### PR TITLE
Adds chrome support to TomatoTomato

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ Key Features:
 - Customizable list of blocked websites
 - Notification upon cycle completion
 
-Pomodoro™/Focus Timer extension for Mozilla. The Pomodoro Technique® and Pomodoro™ are registered trademarks of Francesco Cirillo. 
+Pomodoro™/Focus Timer extension for Mozilla and Chrome. The Pomodoro Technique® and Pomodoro™ are registered trademarks of Francesco Cirillo. 
 

--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -1,0 +1,43 @@
+{
+
+    "manifest_version": 2,
+    "name": "TomatoTomato",
+    "version": "1.0",
+
+    "description": "A Pomodoro/Focus timer extension that blocks distracting websites during your work sessions.", 
+
+    "icons": {
+        "48": "icons/pomo48.png",
+        "96": "icons/pomo96.png"
+    },
+
+    "permissions": [
+        "webRequest",
+        "webRequestBlocking",
+        "<all_urls>",
+        "storage",
+        "notifications"
+    ],
+
+    "web_accessible_resources": [
+        "redirect/blocked.html",
+        "redirect/blocked.css"
+    ],
+
+    "background": {
+        "scripts":["background.js"]
+    },
+
+    "options_ui": {
+        "open_in_tab": true,
+        "page": "options/options.html"
+    },
+
+    "browser_action": {
+        "default_icon": "icons/pomo48.png",
+        "default_title": "TomatoTomato",
+        "default_popup": "popup/menu.html"
+
+    }
+
+}

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,0 +1,50 @@
+{
+
+    "manifest_version": 2,
+    "name": "TomatoTomato",
+    "version": "1.0",
+
+    "applications": {
+        "gecko": {
+          "id": "TomatoTomato@TomatoTomatoPotatoPotato.com",
+          "strict_min_version": "48.0"
+        }
+    },
+
+    "description": "A Pomodoro/Focus timer extension that blocks distracting websites during your work sessions.", 
+
+    "icons": {
+        "48": "icons/pomo48.png",
+        "96": "icons/pomo96.png"
+    },
+
+    "permissions": [
+        "webRequest",
+        "webRequestBlocking",
+        "<all_urls>",
+        "storage",
+        "notifications"
+    ],
+
+    "web_accessible_resources": [
+        "redirect/blocked.html",
+        "redirect/blocked.css"
+    ],
+
+    "background": {
+        "scripts":["background.js"]
+    },
+
+    "options_ui": {
+        "open_in_tab": true,
+        "page": "options/options.html"
+    },
+
+    "browser_action": {
+        "default_icon": "icons/pomo48.png",
+        "default_title": "TomatoTomato",
+        "default_popup": "popup/menu.html"
+
+    }
+
+}

--- a/options/options.js
+++ b/options/options.js
@@ -140,12 +140,11 @@ longRestLengthInput.addEventListener("input", ()=> {
 
 // Save notification setting on click
 popupNotif.addEventListener("change", ()=> {
-    browser.storage.local.get()
-        .then((restoredSettings)=> {
+    chrome.storage.local.get(null,(restoredSettings)=> {
             restoredSettings.popups = popupNotif.checked;
-            browser.storage.local.set(restoredSettings);
-        })
-})
+            chrome.storage.local.set(restoredSettings);
+    });
+});
 
 /**********************************************************************
 * HELPER FUNCTIONS
@@ -160,7 +159,7 @@ popupNotif.addEventListener("change", ()=> {
 function restoreDefaults(event) {
     console.log("restore defaults");
     //For each data member, set userValue to null
-    var gettingStoredSettings = browser.storage.local.get();
+    var gettingStoredSettings = chrome.storage.local.get();
     gettingStoredSettings.then((userSettings)=> {
         userSettings.workLength.userValue       = null;
         userSettings.restLength.userValue       = null;
@@ -169,7 +168,7 @@ function restoreDefaults(event) {
         userSettings.popups                     = true;
 
         // Save settings
-        browser.storage.local.set(userSettings);
+        chrome.storage.local.set(userSettings);
 
         // Update the page
         restoreOptions();
@@ -202,10 +201,8 @@ function isPositiveNumber(inputElement) {
 
 // Saves cycle lengths
 function saveCycleLength(domId) {
-    var gettingStoredSettings = browser.storage.local.get();
-
-    if(domId == "workLength" || domId == "workLengthBtn") {
-        gettingStoredSettings.then((restoredSettings)=> {
+    chrome.storage.local.get(null,function(restoredSettings) {
+        if(domId == "workLength" || domId == "workLengthBtn") {
             restoredSettings.workLength.userValue = workLengthInput.value*MINUTES/SECONDS;
             saveMinutes(restoredSettings);
 
@@ -213,10 +210,8 @@ function saveCycleLength(domId) {
 
             // Clear current text
             workLengthInput.value = null;
-        });
-    }
-    if(domId == "restLength" || domId == "restLengthBtn") {
-        gettingStoredSettings.then((restoredSettings)=> {
+        }
+        if(domId == "restLength" || domId == "restLengthBtn") {
             restoredSettings.restLength.userValue = restLengthInput.value*MINUTES/SECONDS;
             saveMinutes(restoredSettings);
 
@@ -224,10 +219,8 @@ function saveCycleLength(domId) {
 
             // Clear current text
             restLengthInput.value = null;
-        });
-    }
-    if(domId == "longRestLength" || domId == "longRestLengthBtn") {
-        gettingStoredSettings.then((restoredSettings)=> {
+        }
+        if(domId == "longRestLength" || domId == "longRestLengthBtn") {
             restoredSettings.longRestLength.userValue = longRestLengthInput.value*MINUTES/SECONDS;
             saveMinutes(restoredSettings);
 
@@ -235,8 +228,8 @@ function saveCycleLength(domId) {
 
             // Clear current text
             longRestLengthInput.value = null;
-        });
-    }
+        }
+    });
 }
 
 /**********************************************************************
@@ -247,7 +240,7 @@ function saveCycleLength(domId) {
 ***********************************************************************/
 function saveMinutes(settings) {
         // Save updated settings to local storage
-        browser.storage.local.set(settings);
+        chrome.storage.local.set(settings);
 
         // Update displays 
         workDisplay.textContent       = settings.workLength.userValue*SECONDS/MINUTES     || settings.workLength.defaultValue*SECONDS/MINUTES;
@@ -264,8 +257,7 @@ function saveMinutes(settings) {
 ***********************************************************************/
 function saveWebsites() {
 
-    var gettingStoredWebsites = browser.storage.local.get();
-    gettingStoredWebsites.then((restoredSettings)=> {
+    chrome.storage.local.get(null,(restoredSettings)=> {
         // Overwrite block patterns with new list
         restoredSettings.blockPattern.userValue = Array.apply(null, websiteSelect.options).map(
             function(el) { 
@@ -274,7 +266,7 @@ function saveWebsites() {
             }) // this crap is needed because HTMLSelectElement.Option returns stupid stuff
 
         // Save updated website list
-        browser.storage.local.set(restoredSettings);
+        chrome.storage.local.set(restoredSettings);
     });
 }
 
@@ -313,8 +305,7 @@ function restoreOptions() {
     }
   
     // Grabs the settings, then tells it to update input field w that data
-    var gettingStoredSettings = browser.storage.local.get();
-    gettingStoredSettings.then(updateUI, onError);
+    chrome.storage.local.get(null,updateUI);
 }
 
 /**********************************************************************

--- a/popup/menu.js
+++ b/popup/menu.js
@@ -6,7 +6,7 @@ var settingsBtn     = document.getElementById('settings');
 var timerDisplay    = document.getElementById('timer-display');
 
 // Set up listener for updates from background
-browser.runtime.onMessage.addListener(function (message) {
+chrome.runtime.onMessage.addListener(function (message) {
     updateDisplay(message.timeLeft || 0);
     updateBackground(message.cycWorking);
     updateCycle(message.cycCount, message.cycWorking);
@@ -31,7 +31,7 @@ stopBtn.addEventListener("click", ()=> {
 
 // Open options extension options page when settings button is clicked
 settingsBtn.addEventListener("click", ()=> {
-    var opening = browser.runtime.openOptionsPage();
+    var opening = chrome.runtime.openOptionsPage();
 })
 
 
@@ -57,7 +57,7 @@ function updatePopup() {
 * Returns: None
 ***********************************************************************/
 function sendBackgroundMsg(blockOrUnblock) {
-    browser.runtime.sendMessage({action: blockOrUnblock});
+    chrome.runtime.sendMessage({action: blockOrUnblock});
 }
 
 /**********************************************************************


### PR DESCRIPTION
- Converts all 'browser' namespaces to 'chrome
- Replaces all promise-based storage APIs to use callbacks, since
  promises are not supported in Chrome for extensions.
- Adds separate chrome and firefox manifests, since they have different
  requirements and we currently do not have a build system.